### PR TITLE
Update config/autoload/global.php

### DIFF
--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -14,7 +14,7 @@
 return array(
     'db' => array(
         'driver' => 'Pdo',
-        'dsn'            => 'mysql:dbname=zf2tutorial;hostname=localhost',
+        'dsn'            => 'mysql:dbname=zf2tutorial;host=localhost',
         'username'       => 'rob',
         'password'       => '123456',
         'driver_options' => array(


### PR DESCRIPTION
Fixed

'dsn'            => 'mysql:dbname=zf2tutorial;hostname=localhost',
to
'dsn'            => 'mysql:dbname=zf2tutorial;host=localhost',

per post on
http://zend-framework-community.634137.n4.nabble.com/ZF2-Create-database-connection-to-php-cloud-db-server-td4656798.html

... I ran into the same issue.
