### PR TITLE
Refactored AlbumTable to accept a TableGateway instead of acting as one.

### DIFF
--- a/module/Album/Module.php
+++ b/module/Album/Module.php
@@ -2,7 +2,10 @@
 
 namespace Album;
 
+use Album\Model\Album;
 use Album\Model\AlbumTable;
+use Zend\Db\ResultSet\ResultSet;
+use Zend\Db\TableGateway\TableGateway;
 
 class Module
 {
@@ -19,19 +22,25 @@ class Module
             ),
         );
     }
-    
+
     public function getServiceConfig()
     {
         return array(
             'factories' => array(
                 'Album\Model\AlbumTable' =>  function($sm) {
-                    $dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
-                    $table = new AlbumTable($dbAdapter);
+                    $tableGateway = $sm->get('AlbumTableGateway');
+                    $table = new AlbumTable($tableGateway);
                     return $table;
+                },
+                'AlbumTableGateway' => function ($sm) {
+                    $dbAdapter = $sm->get('Zend\Db\Adapter\Adapter');
+                    $resultSetPrototype = new ResultSet();
+                    $resultSetPrototype->setArrayObjectPrototype(new Album());
+                    return new TableGateway('album', $dbAdapter, null, $resultSetPrototype);
                 },
             ),
         );
-    }    
+    }
 
     public function getConfig()
     {

--- a/module/Album/src/Album/Model/AlbumTable.php
+++ b/module/Album/src/Album/Model/AlbumTable.php
@@ -2,33 +2,27 @@
 
 namespace Album\Model;
 
-use Zend\Db\TableGateway\AbstractTableGateway;
-use Zend\Db\Adapter\Adapter;
-use Zend\Db\ResultSet\ResultSet;
+use Zend\Db\TableGateway\TableGateway;
 
-class AlbumTable extends AbstractTableGateway
+class AlbumTable
 {
-    protected $table = 'album';
+    protected $tableGateway;
 
-    public function __construct(Adapter $adapter)
+    public function __construct(TableGateway $tableGateway)
     {
-        $this->adapter = $adapter;
-        $this->resultSetPrototype = new ResultSet();
-        $this->resultSetPrototype->setArrayObjectPrototype(new Album());
-
-        $this->initialize();
+        $this->tableGateway = $tableGateway;
     }
 
     public function fetchAll()
     {
-        $resultSet = $this->select();
+        $resultSet = $this->tableGateway->select();
         return $resultSet;
     }
 
     public function getAlbum($id)
     {
         $id  = (int) $id;
-        $rowset = $this->select(array('id' => $id));
+        $rowset = $this->tableGateway->select(array('id' => $id));
         $row = $rowset->current();
         if (!$row) {
             throw new \Exception("Could not find row $id");
@@ -45,10 +39,10 @@ class AlbumTable extends AbstractTableGateway
 
         $id = (int)$album->id;
         if ($id == 0) {
-            $this->insert($data);
+            $this->tableGateway->insert($data);
         } else {
             if ($this->getAlbum($id)) {
-                $this->update($data, array('id' => $id));
+                $this->tableGateway->update($data, array('id' => $id));
             } else {
                 throw new \Exception('Form id does not exist');
             }
@@ -57,7 +51,7 @@ class AlbumTable extends AbstractTableGateway
 
     public function deleteAlbum($id)
     {
-        $this->delete(array('id' => $id));
+        $this->tableGateway->delete(array('id' => $id));
     }
 
 }


### PR DESCRIPTION
I've been working on incorporating Unit Testing into the [zf2 tutorial documentation](https://github.com/zendframework/zf2-documentation/pull/307) and ran into a wall when testing the AlbumTable class. I believe it makes more sense for the AlbumTable to accept a TableGateway argument rather than extend AbstractTableGateway.

From the docs:

> "The TableGateway concrete implementation simply adds a sensible constructor to the AbstractTableGateway class so that out-of-the-box, TableGateway does not need to be extended in order to be consumed and utilized to its fullest."

The original implementation of AlbumTable doesn't add any gateway-specific functionality (so, arguably, it violates SRP). Even if it did, that special logic could be implemented using the Features API. Also from the docs:

> "In addition, AbstractTableGateway also implements a 'Feature' API, that allows for expanding the behaviors of the base TableGateway implementation without having to extend the class with this new functionality."

I hope you'll agree and accept this Pull Request. See the [corresponding documentation Pull Request](https://github.com/zendframework/zf2-documentation/pull/356) for more info.

Thanks!
